### PR TITLE
Textures constructors and assigment operators improvements

### DIFF
--- a/src/Texture.h
+++ b/src/Texture.h
@@ -2,18 +2,32 @@
 
 class Texture : public ITexture
 {
-	SDL_Texture* texture;
+	SDL_Texture* texture = nullptr;
 
 public:
 
 	explicit Texture(SDL_Texture* tex) : texture(tex) {}
 
-	~Texture() final {
-		if (texture) {
-			SDL_DestroyTexture(texture);
-		}
-	}
+	~Texture() final { SDL_DestroyTexture(texture);	}
 
-	SDL_Texture* GetSDLTexture() const { return texture; }
+    // Deleted copy constructor and assignment operator to prevent accidental resource duplication.
+    Texture(const Texture&) = delete;
+    Texture& operator=(const Texture&) = delete;
+
+    // Implemented move constructor and assignment operator to safely transfer SDL_Texture ownership.
+    Texture(Texture&& other) noexcept : texture(other.texture) { other.texture = nullptr; }
+
+    Texture& operator=(Texture&& other) noexcept {
+        if (this != &other) {
+            if (texture) {
+                SDL_DestroyTexture(texture);
+            }
+            texture = other.texture;
+            other.texture = nullptr;
+        }
+        return *this;
+    }
+
+	SDL_Texture* GetSDLTexture() const noexcept { return texture; }
 
 };


### PR DESCRIPTION
## Summary by Sourcery

Implements move constructor and assignment operator for the Texture class to handle SDL_Texture resource management correctly, preventing memory leaks and double frees. Deletes copy constructor and assignment operator to prevent accidental resource duplication.

Enhancements:
- Implements move constructor and assignment operator to safely transfer SDL_Texture ownership.
- Deletes copy constructor and assignment operator to prevent accidental resource duplication.
- Ensures the texture pointer is initialized to nullptr to avoid dangling pointer issues.
- Adds noexcept specifier to move constructor and assignment operator.
- Marks GetSDLTexture() as noexcept.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance `Texture` class by setting default `SDL_Texture*` to `nullptr`, deleting copy constructor and assignment operator, and implementing move constructor and assignment operator.

### Why are these changes being made?

These changes prevent accidental resource duplication through deleted copy operations, ensuring better resource management, and introduce move semantics for efficient transfer of SDL_Texture ownership, mitigating potential resource leaks and improving the class's safety and performance.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the management and cleanup of graphical assets, resulting in improved stability and performance.
  - Streamlined resource handling to prevent potential issues, ensuring a more reliable and responsive experience overall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->