### PR TITLE
Introduced Awake/Start logic for components

### DIFF
--- a/include/Components/Animation.h
+++ b/include/Components/Animation.h
@@ -17,6 +17,6 @@ class Animation : public BaseComponent {
 
 public:
 	Animation(float duration_, float targetX_, float targetY_, int loops_ = 1);
-	void Start() override;
+	void Awake() override;
 	void Update(float deltaTime) override;
 };

--- a/include/Components/BaseComponent.h
+++ b/include/Components/BaseComponent.h
@@ -7,12 +7,13 @@ class BaseComponent {
 protected:
 	GameObject* gameObject = nullptr; // Reference to root GameObject
 	bool active = true;
-
+	
 public:
 	virtual ~BaseComponent() = default;
 	void SetGameObject(GameObject* go) { gameObject = go; }
 	GameObject* GetGameObject() { return gameObject; }
-	virtual void Start() {}
+	virtual void Awake() {} //Called when object added to scene
+	virtual void Start() {} //Called at the first scene update
 	virtual void Update(float deltaTime) {}
 	virtual void OnCollide(GameObject* other) {}
 	void SetActive(bool active_) { active = active_; OnActive(active); }

--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -20,7 +20,7 @@ class GameObject {
     TileTransform* transform = nullptr;
     std::vector<GameObject*> children;
     GameObject* parent = nullptr;
-    bool isStartCalled = false;
+    bool isStarted = false;
 
 public:
     //GameObject() = delete;
@@ -33,6 +33,8 @@ public:
     void SetActive(bool active);
     void AddGameObject(std::unique_ptr<GameObject> go);
     void AddComponent(std::unique_ptr<BaseComponent> component);
+
+    bool HasStarted() { return isStarted; }
 
     template<typename T>
     T* GetComponent() {

--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -20,6 +20,7 @@ class GameObject {
     TileTransform* transform = nullptr;
     std::vector<GameObject*> children;
     GameObject* parent = nullptr;
+    bool isStartCalled = false;
 
 public:
     //GameObject() = delete;
@@ -42,7 +43,8 @@ public:
         return nullptr;
     }
 
-    void Start() const;
+    void Awake() const;
+    void Start();
     void Update(float deltaTime) const;
     void OnCollide(GameObject* other) const;
 

--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -34,7 +34,7 @@ public:
     void AddGameObject(std::unique_ptr<GameObject> go);
     void AddComponent(std::unique_ptr<BaseComponent> component);
 
-    bool HasStarted() { return isStarted; }
+    bool HasStarted() const { return isStarted; }
 
     template<typename T>
     T* GetComponent() {

--- a/include/Input.h
+++ b/include/Input.h
@@ -25,7 +25,7 @@ private:
 
     std::unordered_map<SDL_Keycode, Key> keyMap;
     
-    bool quitRequestedThisFrame;
+    bool quitRequestedThisFrame = false;
 
 public:
     Input();

--- a/include/Scripts/AppleLogic.h
+++ b/include/Scripts/AppleLogic.h
@@ -8,6 +8,6 @@ class AppleLogic : public BaseComponent {
     MazeGenerator* mazeGenerator = nullptr;
 
 public:
-    void Start() override;
+    void Awake() override;
     void RegenerateApple();
 };

--- a/include/Scripts/EndScreenLogic.h
+++ b/include/Scripts/EndScreenLogic.h
@@ -10,7 +10,7 @@ private:
     TexturesManager& textureManager;
     int score = 0;
     std::shared_ptr<ITexture> texture;
-    GameStateManager* stateManager;
+    GameStateManager* stateManager = nullptr;
 
 public:
     EndScreenLogic(TexturesManager& textureManager_);

--- a/include/Scripts/MainMenuLogic.h
+++ b/include/Scripts/MainMenuLogic.h
@@ -12,9 +12,9 @@ class GameStateManager;
 class MainMenuLogic : public BaseComponent {
     TexturesManager& textureManager;
     std::shared_ptr<ITexture> buttonTexture;
-    GameObject* bg;
-    GameObject* startButton;
-    GameStateManager* stateManager;
+    GameObject* bg = nullptr;
+    GameObject* startButton = nullptr;
+    GameStateManager* stateManager = nullptr;
 
 public:
     MainMenuLogic(TexturesManager& textureManager_);

--- a/include/Scripts/MazeGenerator.h
+++ b/include/Scripts/MazeGenerator.h
@@ -18,5 +18,5 @@ public:
     MazeGenerator() = default;
     bool IsObstacle(int x, int y);
     std::pair<int,int> GetRandomEmptyPosition();
-    void Start() override;
+    void Awake() override;
 };

--- a/include/Scripts/SnakeLogic.h
+++ b/include/Scripts/SnakeLogic.h
@@ -26,7 +26,7 @@ class SnakeLogic : public BaseComponent {
 	IInputHandler* inputHandler = nullptr;
 
 public:
-	void Start() override;
+	void Awake() override;
 	void Update(float deltaTime) override;
 	void OnCollide(GameObject* other) override;
 	int GetScore();

--- a/src/Components/Animation.cpp
+++ b/src/Components/Animation.cpp
@@ -19,7 +19,7 @@ float Animation::EaseInOutQuad(float t) const {
     return t < 0.5f ? 2.0f * t * t : 1.0f - std::pow(-2.0f * t + 2.0f, 2.0f) / 2.0f;
 }
 
-void Animation::Start() {
+void Animation::Awake() {
     const TileTransform* transform = gameObject->GetTransform();
     startX = transform->GetScaleX();
     startY = transform->GetScaleY();

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -54,9 +54,18 @@ inline void GameObject::ForEachActiveComponent(Func f) const
     }
 }
 
-void GameObject::Start() const
+void GameObject::Awake() const
 {
-    ForEachActiveComponent([](const auto& comp) { comp->Start(); });
+    ForEachActiveComponent([](const auto& comp) { comp->Awake(); });
+}
+
+void GameObject::Start()
+{
+    if (!isStartCalled)
+    {
+        ForEachActiveComponent([](const auto& comp) { comp->Start(); });
+        isStartCalled = true;
+    }
 }
 
 void GameObject::Update(float deltaTime) const

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -61,11 +61,8 @@ void GameObject::Awake() const
 
 void GameObject::Start()
 {
-    if (!isStartCalled)
-    {
-        ForEachActiveComponent([](const auto& comp) { comp->Start(); });
-        isStartCalled = true;
-    }
+    ForEachActiveComponent([](const auto& comp) { comp->Start(); });
+    isStarted = true;
 }
 
 void GameObject::Update(float deltaTime) const

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -25,7 +25,7 @@ void Scene::AddGameObject(std::unique_ptr<GameObject> go) {
         colliders.push_back(collider);
     }
 
-    go->Start();
+    go->Awake();
     gameObjects.push_back(std::move(go));
 }
 
@@ -46,7 +46,11 @@ void Scene::CheckCollisions() {
 }
 
 void Scene::Update(float deltaTime) {
-    for (auto& go : gameObjects) go->Update(deltaTime);
+    for (auto& go : gameObjects)
+    {
+        go->Start(); //called only once
+        go->Update(deltaTime);
+    }
 }
 
 void Scene::Render() {

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -48,7 +48,11 @@ void Scene::CheckCollisions() {
 void Scene::Update(float deltaTime) {
     for (auto& go : gameObjects)
     {
-        go->Start(); //called only once
+        if (!go->HasStarted())
+        {
+            go->Start(); //called only once
+        }
+
         go->Update(deltaTime);
     }
 }

--- a/src/Scripts/AppleLogic.cpp
+++ b/src/Scripts/AppleLogic.cpp
@@ -4,7 +4,7 @@
 #include "Scripts/GameConsts.h"
 #include "Components/Transform.h"
 
-void AppleLogic::Start() {
+void AppleLogic::Awake() {
     mazeGenerator = gameObject->GetScene()->FindGameObjectByName("maze_generator")->GetComponent<MazeGenerator>();
     gameObject->GetTransform()->SetSize(TILE_SIZE, TILE_SIZE);
     RegenerateApple();

--- a/src/Scripts/EndScreenLogic.cpp
+++ b/src/Scripts/EndScreenLogic.cpp
@@ -35,8 +35,6 @@ void EndScreenLogic::Start() {
 }
 
 void EndScreenLogic::Update(float deltaTime) {
-    if (!gameObject) return; // Skip if deactivated
-
     auto scene = gameObject->GetScene();
     auto& input = scene->GetInput();
 

--- a/src/Scripts/MainMenuLogic.cpp
+++ b/src/Scripts/MainMenuLogic.cpp
@@ -49,8 +49,7 @@ void MainMenuLogic::OnActive(bool active) {
 }
 
 void MainMenuLogic::Update(float deltaTime) {
-    if (!gameObject) return; // Skip if deactivated
-
+    
     auto scene = gameObject->GetScene();
     auto& input = scene->GetInput();
 

--- a/src/Scripts/MainMenuLogic.cpp
+++ b/src/Scripts/MainMenuLogic.cpp
@@ -12,7 +12,7 @@
 #include "GameObjectBuilder.h"  // Include the builder header
 
 MainMenuLogic::MainMenuLogic(TexturesManager& textureManager_)
-    : textureManager(textureManager_), bg(nullptr), startButton(nullptr)
+    : textureManager(textureManager_)
 {
 }
 
@@ -33,8 +33,14 @@ void MainMenuLogic::Start() {
         .WithComponent<SpriteRenderer>(buttonTexture)
         .AddToScene();
 
-    stateManager = scene->FindGameObjectByName("StateMachineRoot")
-        ->GetComponent<GameStateManager>();
+    auto stateManagerObject = scene->FindGameObjectByName("StateMachineRoot");
+        
+    if (stateManagerObject == nullptr)
+    {
+        SDL_Log("stateManagerObject == null");
+    }
+
+    stateManager = stateManagerObject->GetComponent<GameStateManager>();
 }
 
 void MainMenuLogic::OnActive(bool active) {

--- a/src/Scripts/MazeGenerator.cpp
+++ b/src/Scripts/MazeGenerator.cpp
@@ -122,6 +122,6 @@ std::pair<int, int> MazeGenerator::GetRandomEmptyPosition() {
     return { x, y };
 }
 
-void MazeGenerator::Start() {
+void MazeGenerator::Awake() {
     GenerateMaze(WIDTH / 2, HEIGHT / 2);
 }

--- a/src/Scripts/SnakeLogic.cpp
+++ b/src/Scripts/SnakeLogic.cpp
@@ -14,7 +14,7 @@
 
 #include "Scripts/GameConsts.h"
 
-void SnakeLogic::Start() {
+void SnakeLogic::Awake() {
     inputHandler = gameObject->GetComponent<IInputHandler>();
     mazeGenerator = gameObject->GetScene()->FindGameObjectByName("maze_generator")->GetComponent<MazeGenerator>();
     apple = gameObject->GetScene()->FindGameObjectByName("apple")->GetComponent<AppleLogic>();


### PR DESCRIPTION
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Separate component initialization into Awake and Start phases by introducing Awake(), deferring Start() until the first update, renaming existing Start overrides, updating scene/gameobject logic accordingly, and adding default member initializations and a null check in MainMenuLogic

New Features:
- Introduce Awake() lifecycle method invoked when a GameObject is added to the scene
- Add Start() phase in GameObject to execute component Start logic exactly once on the first update

Bug Fixes:
- Add null check and logging when acquiring the GameStateManager in MainMenuLogic

Enhancements:
- Rename existing component Start overrides to Awake and adjust Scene/GameObject to distinguish Awake and Start phases
- Default-initialize member pointers and flags such as isStartCalled and quitRequestedThisFrame

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Added an Awake lifecycle hook invoked when objects are added to the scene.
  - Start now runs once (idempotent) before the first Update; components and scripts moved initialization to Awake.

- Bug Fixes
  - Initialized several pointers and a quit-request flag to safe defaults to avoid uninitialized state.
  - Added a null check in menu logic during state manager lookup for improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->