### PR TITLE
Main menu fix

### DIFF
--- a/include/GameObject.h
+++ b/include/GameObject.h
@@ -71,5 +71,5 @@ public:
     void ForEachActiveComponent(Func f) const;
 
     bool IsAncestorOf(const std::string& name, unsigned tag) const;
-    GameObjectBuilder CreateChildBuilder(const std::string& name, unsigned tag);
+    GameObjectBuilder CreateGameObjectBuilder(const std::string& name, unsigned tag);
 };

--- a/include/Scene.h
+++ b/include/Scene.h
@@ -49,7 +49,7 @@ public:
 	const std::vector<std::unique_ptr<GameObject>>& GetGameObjects() const;
 	const IRenderer* GetRenderer() const;
 		
-	GameObjectBuilder CreateGameObjectBuilder(const std::string& name, unsigned tag);
+	GameObjectBuilder CreateGameObjectBuilder(const std::string& name, unsigned tag = 0);
 
 	const Input& GetInput() const;
 	

--- a/include/Scripts/EndScreenLogic.h
+++ b/include/Scripts/EndScreenLogic.h
@@ -11,6 +11,8 @@ private:
     int score = 0;
     std::shared_ptr<ITexture> texture;
     GameStateManager* stateManager = nullptr;
+    GameObject* gameOverText = nullptr;
+    GameObject* bg = nullptr;
 
 public:
     EndScreenLogic(TexturesManager& textureManager_);

--- a/include/Scripts/MainMenuLogic.h
+++ b/include/Scripts/MainMenuLogic.h
@@ -20,6 +20,5 @@ public:
     MainMenuLogic(TexturesManager& textureManager_);
 
     void Start() override;
-    void OnActive(bool active) override;
     void Update(float deltaTime) override;
 };

--- a/src/GameObject.cpp
+++ b/src/GameObject.cpp
@@ -104,7 +104,7 @@ bool GameObject::IsAncestorOf(const std::string& name, unsigned tag) const
     return false;
 }
 
-GameObjectBuilder GameObject::CreateChildBuilder(const std::string& name_, unsigned tag_)
+GameObjectBuilder GameObject::CreateGameObjectBuilder(const std::string& name_, unsigned tag_)
 {
     if (IsAncestorOf(name_, tag_))
     {

--- a/src/Scripts/EndScreenLogic.cpp
+++ b/src/Scripts/EndScreenLogic.cpp
@@ -19,16 +19,16 @@ void EndScreenLogic::Start() {
     auto scene = gameObject->GetScene();
 
     // End Background
-    scene->CreateGameObjectBuilder("EndBackground", 0)
+    bg = gameObject->CreateGameObjectBuilder("EndBackground", 0)
         .WithComponent<TileTransform>(0, 0, WIDTH * TILE_SIZE, HEIGHT * TILE_SIZE)
-        .WithComponent<RectRenderer>(20, 20, 20)
+        .WithComponent<RectRenderer>(0, 0, 255)
         .AddToScene();
 
     // Game Over Text
-    scene->CreateGameObjectBuilder("GameOverText", 0)
+    /*gameOverText = gameObject->CreateGameObjectBuilder("GameOverText", 0)
         .WithComponent<TileTransform>(WIDTH / 2 - 2, HEIGHT / 2 - 4, 32, 32)
         .WithComponent<SpriteRenderer>(texture)
-        .AddToScene();
+        .AddToScene();*/
 
     stateManager = scene->FindGameObjectByName("StateMachineRoot")
         ->GetComponent<GameStateManager>();

--- a/src/Scripts/GameStateManager.cpp
+++ b/src/Scripts/GameStateManager.cpp
@@ -13,6 +13,7 @@ void GameStateManager::Start() {
 }
 
 void GameStateManager::TransitionTo(GameState newState) {
+       
     // Deactivate all roots
     if (mainMenuRoot) mainMenuRoot->SetActive(false);
     if (gameModeRoot) gameModeRoot->SetActive(false);

--- a/src/Scripts/MainMenuLogic.cpp
+++ b/src/Scripts/MainMenuLogic.cpp
@@ -22,30 +22,20 @@ void MainMenuLogic::Start() {
     auto scene = gameObject->GetScene();
 
     // Menu Background
-    bg = scene->CreateGameObjectBuilder("MenuBackground", 0)
-        .WithComponent<TileTransform>(0, 0, WIDTH * TILE_SIZE, HEIGHT * TILE_SIZE)
-        .WithComponent<RectRenderer>(50, 50, 50)
+    bg = gameObject->CreateGameObjectBuilder("MenuBackground", 0)
+        .WithComponent<TileTransform>(0, 0, WIDTH * TILE_SIZE/2 , HEIGHT * TILE_SIZE/2)
+        .WithComponent<RectRenderer>(255, 0, 0)
         .AddToScene();
 
     // Start Button
-    startButton = scene->CreateGameObjectBuilder("StartButton", 0)
+    /*startButton = gameObject->CreateGameObjectBuilder("StartButton", 0)
         .WithComponent<TileTransform>(WIDTH / 2 - 2, HEIGHT / 2 - 2, 32, 32)
         .WithComponent<SpriteRenderer>(buttonTexture)
-        .AddToScene();
+        .AddToScene();*/
 
     auto stateManagerObject = scene->FindGameObjectByName("StateMachineRoot");
-        
-    if (stateManagerObject == nullptr)
-    {
-        SDL_Log("stateManagerObject == null");
-    }
-
+   
     stateManager = stateManagerObject->GetComponent<GameStateManager>();
-}
-
-void MainMenuLogic::OnActive(bool active) {
-    bg->SetActive(active);
-    startButton->SetActive(active);
 }
 
 void MainMenuLogic::Update(float deltaTime) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -98,7 +98,7 @@ int main(int argc, char* argv[]) {
 		.Build();*/
 
 		// Border (as child of root)
-	root->CreateChildBuilder("border", 0)
+	root->CreateGameObjectBuilder("border", 0)
 		.WithComponent<TileTransform>(0, 0, WIDTH * TILE_SIZE, HEIGHT * TILE_SIZE)
 		.WithComponent<RectRenderer>(255, 255, 255)
 		.AddToScene();


### PR DESCRIPTION
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Summary by Sourcery

Unify game object builder API, update UI background dimensions and colors for main menu and end screen, and disable unfinished UI components

Enhancements:
- Rename GameObject::CreateChildBuilder to CreateGameObjectBuilder and add an optional tag parameter to Scene::CreateGameObjectBuilder
- Use gameObject-based builders and adjust background sizes and colors in the main menu (half-scale red) and end screen (blue)

Chores:
- Comment out start button and game over text creation in MainMenuLogic and EndScreenLogic
- Remove the OnActive override and redundant null check from MainMenuLogic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Main menu background resized to half and changed to red.
  - End screen background color updated to blue.
- UI Changes
  - Start button removed from the main menu.
  - Game-over text no longer displayed on the end screen.
- Refactor
  - Unified object creation terminology for consistency.
  - Simplified object creation with a default tag value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->